### PR TITLE
Doc(#2): adição de revisores e atualização do documento

### DIFF
--- a/docs/planejamento/Definição_de_Equipe_e_Responsabilidades.md
+++ b/docs/planejamento/Definição_de_Equipe_e_Responsabilidades.md
@@ -69,4 +69,4 @@ Para a escolha do **Scrum Master** e do **Product Owner (PO)**, foi utilizado um
 
 | Versão | Data       | Descrição            | Autor(es)                                                                                           | Revisor(es)                                      |
 | ------ | ---------- | -------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
-| `1.0`  | 09/04/2025 | Criação do documento | [Lucas Alves](https://github.com/LucasAlves71)                                                        |                                                  |
+| `1.0`  | 09/04/2025 | Criação do documento | [Lucas Alves](https://github.com/LucasAlves71) | [Yzabella Miranda](https://github.com/redjsun) |


### PR DESCRIPTION
Este pull request atualiza o arquivo docs/planejamento/Definição_de_Equipe_e_Responsabilidades.md para incluir um revisor na entrada de criação do documento, garantindo maior responsabilidade e rastreabilidade.

* [`docs/planejamento/Definição_de_Equipe_e_Responsabilidades.md`](diffhunk://#diff-fd5be9fed3ddce2a50e6184eefc21824363061c92b7b34ac33fa78eed05dc166L72-R72): adição do documento de Definição da Equipe e Suas Responsabilidades do grupo.

* [`docs/planejamento/Definição_de_Equipe_e_Responsabilidades.md`](diffhunk://#diff-fd5be9fed3ddce2a50e6184eefc21824363061c92b7b34ac33fa78eed05dc166L72-R72): Adicionou [Yzabella Miranda](https://github.com/redjsun) como revisora da primeira versão do documento.